### PR TITLE
Fixed crash in mumu and bluestack emulators

### DIFF
--- a/zstring.cs
+++ b/zstring.cs
@@ -766,6 +766,8 @@ namespace GameFramework
         }
         private unsafe static void byteCopy(byte* dest, byte* src, int byteCount)
         {
+            Buffer.MemoryCopy(src, dest, byteCount, byteCount);
+            return;
             if (byteCount < 128)
             {
                 goto g64;


### PR DESCRIPTION
~~~
using UnityEngine;
using ZString;

public class zstringTest : MonoBehaviour
{
    // Start is called before the first frame update
    void Start()
    {
        using (zstring.Block())
        {
            var missionID = (zstring)"xxxxxx";
            var intv = (zstring)12345;
            // crash in mumu and bluestack emulators
            var zzzz = missionID + intv;
            Debug.LogError(zzzz.ToString());
        }
    }

}
~~~